### PR TITLE
Fix error code mixup between ErrorCorrupt and ErrorNotFound

### DIFF
--- a/Database/SQLite3.hsc
+++ b/Database/SQLite3.hsc
@@ -53,8 +53,8 @@ data Error = ErrorOK
            | ErrorReadOnly
            | ErrorInterrupt
            | ErrorIO
-           | ErrorNotFound
            | ErrorCorrupt
+           | ErrorNotFound
            | ErrorFull
            | ErrorCan'tOpen
            | ErrorProtocol
@@ -102,8 +102,8 @@ encodeError ErrorNoMemory = 7
 encodeError ErrorReadOnly = 8
 encodeError ErrorInterrupt = 9
 encodeError ErrorIO = 10
-encodeError ErrorNotFound = 11
-encodeError ErrorCorrupt = 12
+encodeError ErrorCorrupt = 11
+encodeError ErrorNotFound = 12
 encodeError ErrorFull = 13
 encodeError ErrorCan'tOpen = 14
 encodeError ErrorProtocol = 15
@@ -134,8 +134,8 @@ decodeError 7 = ErrorNoMemory
 decodeError 8 = ErrorReadOnly
 decodeError 9 = ErrorInterrupt
 decodeError 10 = ErrorIO
-decodeError 11 = ErrorNotFound
-decodeError 12 = ErrorCorrupt
+decodeError 11 = ErrorCorrupt
+decodeError 12 = ErrorNotFound
 decodeError 13 = ErrorFull
 decodeError 14 = ErrorCan'tOpen
 decodeError 15 = ErrorProtocol


### PR DESCRIPTION
The [persistent-sqlite3](http://hackage.haskell.org/package/persistent-sqlite) package copied this mistake.  To avoid having to maintain this list in two places, I wrote a package called "sqlite3-error-codes", which contains nothing but `Error`, `encodeError`, and `decodeError`, plus documentation copied from [SQLite3's documentation](http://www.sqlite.org/c3ref/c_abort.html).  However, I haven't released it yet.  Do you mind if I release it as public domain?  More precisely, I'm asking for permission to use the data constructor names like `ErrorCan'tOpen`.
