### PR TITLE
Use String instead of Text for open filename

### DIFF
--- a/Database/SQLite3.hs
+++ b/Database/SQLite3.hs
@@ -186,9 +186,9 @@ appendShow txt a = txt `T.append` (T.pack . show) a
 
 
 -- | <http://www.sqlite.org/c3ref/open.html>
-open :: Text -> IO Database
+open :: String -> IO Database
 open path =
-    Direct.open (toUtf8 path)
+    Direct.open (toUtf8 . T.pack $ path)
         >>= checkErrorMsg ("open " `appendShow` path)
 
 -- | <http://www.sqlite.org/c3ref/close.html>


### PR DESCRIPTION
Most operations on filenames in Haskell libraries are using Strings instead of Text, so use String for "open".

I realize this is debatable but pushing the change anyway.  Performance-wise this shouldn't matter.  It's a question of consistency: whether to be consistent with other APIs that operate on filenames or to be consistent within direct-sqlite and the decision to use Text for everything.
