### PR TITLE
lower required text library version

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -1,5 +1,5 @@
 name: direct-sqlite
-version: 2.2
+version: 2.2.1
 build-type: Simple
 license: BSD3
 license-file: LICENSE
@@ -21,6 +21,9 @@ description:
   as ByteStrings.
   .
   Release history:
+  .
+  [Version 2.2.1] Bump down text library version to match with the
+  latest Haskell Platform.
   .
   [Version 2.2] actually does what version 2.1 claimed to, since the author
   made a mistake with git.


### PR DESCRIPTION
Haskell Platform provides text-0.11.2.0 but direct-sqlite was
requiring text-0.11.2.2.  This caused installation of direct-sqlite to
install another copy of text which lead to linking problems for some
users.

See issue #18 on github.

Bumped up direct-sqlite library version to 2.2.1 from 2.2.  This is switching to a.b.c from a.b scheme.  I think it makes sense this way so that docs updates and minor tweaks like this can just bump up the .c part of the version.
