### PR TITLE
Work around linker error when ghc is invoked by itself

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -76,6 +76,9 @@ Library
     cpp-options: -Ddirect_sqlite_systemlib
     extra-libraries: sqlite3
   } else {
+    if !os(windows) {
+      extra-libraries: pthread
+    }
     c-sources: cbits/sqlite3.c
   }
 


### PR DESCRIPTION
I was getting the following error on Ubuntu 13.04 when using "ghc -Wall -O2"
to compile a program using direct-sqlite:

```
/usr/bin/ld: /home/joey/.cabal/lib/direct-sqlite-2.3.3.1/ghc-7.6.2/libHSdirect-sqlite-2.3.3.1.a(sqlite3.o): undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.1'
/usr/bin/ld: note: 'pthread_mutexattr_settype@@GLIBC_2.1' is defined in DSO /lib/i386-linux-gnu/libpthread.so.0 so try adding it to the linker command line
/lib/i386-linux-gnu/libpthread.so.0: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
```

The error does not happen if I build direct-sqlite with `-fsystemlib` or compile my program with `-threaded`.

I think the problem is described here: [UnderstandingDSOLinkChange](https://fedoraproject.org/wiki/UnderstandingDSOLinkChange).  Simply put, `sqlite3.c` needs `pthread`, but we didn't have an `extra-libraries` line for it.  We were just taking it for granted because GHC also needed it.
