### PR TITLE
Add columnName (sqlite3_column_name)

### DIFF
--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -30,6 +30,7 @@ module Database.SQLite3.Bindings (
     c_sqlite3_bind_parameter_count,
     c_sqlite3_bind_parameter_name,
     c_sqlite3_column_count,
+    c_sqlite3_column_name,
 
     -- * Binding Values To Prepared Statements
     -- | <http://www.sqlite.org/c3ref/bind_blob.html>
@@ -195,6 +196,10 @@ foreign import ccall unsafe "sqlite3_bind_parameter_name"
 -- | <http://www.sqlite.org/c3ref/column_count.html>
 foreign import ccall unsafe "sqlite3_column_count"
     c_sqlite3_column_count :: Ptr CStatement -> IO CColumnCount
+
+-- | <http://www.sqlite.org/c3ref/column_name.html>
+foreign import ccall unsafe "sqlite3_column_name"
+    c_sqlite3_column_name :: Ptr CStatement -> CColumnIndex -> IO CString
 
 
 foreign import ccall unsafe "sqlite3_bind_blob"

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -33,6 +33,7 @@ module Database.SQLite3.Direct (
     bindParameterCount,
     bindParameterName,
     columnCount,
+    columnName,
 
     -- * Binding values to a prepared statement
     -- | <http://www.sqlite.org/c3ref/bind_blob.html>
@@ -390,6 +391,12 @@ bindParameterName (Statement stmt) idx =
 columnCount :: Statement -> IO ColumnCount
 columnCount (Statement stmt) =
     fromFFI <$> c_sqlite3_column_count stmt
+
+-- | <http://www.sqlite.org/c3ref/column_name.html>
+columnName :: Statement -> ColumnIndex -> IO (Maybe Utf8)
+columnName (Statement stmt) idx =
+    c_sqlite3_column_name stmt (toFFI idx) >>=
+        packUtf8 Nothing Just
 
 bindInt64 :: Statement -> ParamIndex -> Int64 -> IO (Either Error ())
 bindInt64 (Statement stmt) idx value =


### PR DESCRIPTION
This adds support for `sqlite3_column_name`, which returns the name of a result column.  Example:

```
> import Database.SQLite3
> conn <- open ":memory:"
> exec conn "CREATE TABLE foo (abc TEXT, d INT)"
> stmt <- prepare conn "SELECT *, randomblob(32) FROM foo"
> columnName stmt 0
Just "abc"
> columnName stmt 1
Just "d"
> columnName stmt 2
Just "randomblob(32)"
> columnName stmt 3
Nothing
```

@nurpax: This might be an easy way to provide column information for conversion errors in sqlite-simple (https://github.com/nurpax/sqlite-simple/issues/20).
