### PR TITLE
Add getAutoCommit (sqlite3_get_autocommit)

### DIFF
--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -10,6 +10,7 @@ module Database.SQLite3.Bindings (
     c_sqlite3_trace,
     CTraceCallback,
     mkCTraceCallback,
+    c_sqlite3_get_autocommit,
 
     -- * Simple query execution
     -- | <http://sqlite.org/c3ref/exec.html>
@@ -90,6 +91,10 @@ foreign import ccall "sqlite3_trace"
         -> Ptr a                     -- ^ Context passed to the callback
         -> IO (Ptr ())               -- ^ Returns context pointer from previously
                                      --   registered trace
+
+-- | <http://www.sqlite.org/c3ref/get_autocommit.html>
+foreign import ccall unsafe "sqlite3_get_autocommit"
+    c_sqlite3_get_autocommit :: Ptr CDatabase -> IO CInt
 
 
 foreign import ccall "sqlite3_exec"

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -13,6 +13,7 @@ module Database.SQLite3.Direct (
     close,
     errmsg,
     setTrace,
+    getAutoCommit,
 
     -- * Simple query execution
     -- | <http://sqlite.org/c3ref/exec.html>
@@ -309,6 +310,24 @@ setTrace (Database db) logger =
                 output msg
             _ <- c_sqlite3_trace db cb nullPtr
             return ()
+
+-- | <http://www.sqlite.org/c3ref/get_autocommit.html>
+--
+-- Return 'True' if the connection is in autocommit mode, or 'False' if a
+-- transaction started with @BEGIN@ is still active.
+--
+-- Be warned that some errors roll back the transaction automatically,
+-- and that @ROLLBACK@ will throw an error if no transaction is active.
+-- Use 'getAutoCommit' to avoid such an error:
+--
+-- @
+--  autocommit <- 'getAutoCommit' conn
+--  'Control.Monad.when' (not autocommit) $
+--      'Database.SQLite3.exec' conn \"ROLLBACK\"
+-- @
+getAutoCommit :: Database -> IO Bool
+getAutoCommit (Database db) =
+    (/= 0) <$> c_sqlite3_get_autocommit db
 
 -- | <http://www.sqlite.org/c3ref/prepare.html>
 --

--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -110,6 +110,7 @@ test-suite test
                     , OverloadedStrings
                     , Rank2Types
                     , RecordWildCards
+                    , ScopedTypeVariables
 
   build-depends: base
                , base16-bytestring


### PR DESCRIPTION
I encountered a problem with this pattern:

``` haskell
withTransaction :: Database -> IO a -> IO a
withTransaction conn body =
  mask $ \restore -> do
    exec conn "BEGIN"
    a <- restore (body a) `onException` exec conn "ROLLBACK"
    exec conn "COMMIT"
    return a
```

Namely, `ROLLBACK` throws an exception if no transaction is in progress, and some errors automatically roll back the transaction.  To address this problem precisely, I need a binding for [sqlite3_get_autocommit](http://www.sqlite.org/c3ref/get_autocommit.html):

``` haskell
withTransaction :: Database -> IO a -> IO a
withTransaction conn body =
  mask $ \restore -> do
    exec conn "BEGIN"
    a <- restore (body a) `onException` do
        autocommit <- getAutoCommit conn
        when (not autocommit) $ exec conn "ROLLBACK"
    exec conn "COMMIT"
    return a
```

I only exported this from Database.SQLite3.Direct to avoid cluttering the main API, and in case we want to use a more intuitive name than SQLite uses, like:

```
active <- isTransactionActive conn
when active $ exec conn "ROLLBACK"
```
