### PR TITLE
Enable travis continuous integration builds for direct-sqlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: haskell


### PR DESCRIPTION
Enable automated builds to automatically find regressions on pull
requests or git pushes.  Great for rejecting PRs that break the build
or tests.

Irene: need this file + the steps in http://about.travis-ci.org/docs/user/getting-started/.  I can't do the latter part as I don't own your repo.  I use this for a couple of projects and it's GREAT!
