### PR TITLE
Narrow Param/ColumnIndex bounds down to native C 'int' size

### DIFF
--- a/Database/SQLite3/Bindings/Types.hsc
+++ b/Database/SQLite3/Bindings/Types.hsc
@@ -124,6 +124,11 @@ newtype ParamIndex = ParamIndex Int
 instance Show ParamIndex where
     show (ParamIndex n) = show n
 
+-- | Limit min/max bounds to fit into SQLite's native parameter ranges.
+instance Bounded ParamIndex where
+    minBound = ParamIndex (fromIntegral (minBound :: CInt))
+    maxBound = ParamIndex (fromIntegral (maxBound :: CInt))
+
 -- | Index of a column in a result set.  Column indices start from 0.
 newtype ColumnIndex = ColumnIndex Int
     deriving (Eq, Ord, Enum, Num, Real, Integral)
@@ -131,6 +136,11 @@ newtype ColumnIndex = ColumnIndex Int
 -- | This just shows the underlying integer, without the data constructor.
 instance Show ColumnIndex where
     show (ColumnIndex n) = show n
+
+-- | Limit min/max bounds to fit into SQLite's native parameter ranges.
+instance Bounded ColumnIndex where
+    minBound = ColumnIndex (fromIntegral (minBound :: CInt))
+    maxBound = ColumnIndex (fromIntegral (maxBound :: CInt))
 
 -- | Number of columns in a result set.
 type ColumnCount = ColumnIndex

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -407,8 +407,8 @@ testColumnName TestEnv{..} = TestCase $ do
               Just "y"  <- columnName stmt 2
               Just "ü"  <- columnName stmt 3
               Nothing   <- columnName stmt 4
-              Nothing   <- columnName stmt (ColumnIndex minBound)
-              Nothing   <- columnName stmt (ColumnIndex maxBound)
+              Nothing   <- columnName stmt minBound
+              Nothing   <- columnName stmt maxBound
               return ()
       checkNames
       Row <- step stmt
@@ -427,8 +427,8 @@ testColumnName TestEnv{..} = TestCase $ do
       Just "123"  <- columnName stmt 2
       Just "über" <- columnName stmt 3
       Nothing     <- columnName stmt 4
-      Nothing     <- columnName stmt (ColumnIndex minBound)
-      Nothing     <- columnName stmt (ColumnIndex maxBound)
+      Nothing     <- columnName stmt minBound
+      Nothing     <- columnName stmt maxBound
       return ()
 
 -- Testing for specific error codes:


### PR DESCRIPTION
SQLite3 accepts column and parameter indices as native 'int's, which
on 64-bit systems is usually only 32-bits whereas Haskell's Int is
64-bits on 64-bit systems.  Add Bounded instances for ParamIndex and
ColumnIndex to mark the allowable integer range for these values.

No explicit overflow checking is done for these values as this is
somewhat of a corner case and we don't want to pay any extra for such
often used values.

Fixes a test failure reported in #32

---

FYI, tested 

```
          print (minBound :: ColumnIndex)
          print (maxBound :: ColumnIndex)
          print (minBound :: ParamIndex)
          print (maxBound :: ParamIndex)
```

and these correctly print -2147483648 & 2147483647 as expected.
