### PR TITLE
Allow text 1.0 and 1.1

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -109,7 +109,7 @@ Library
   include-dirs: .
   build-depends: base >= 4.1 && < 5,
                  bytestring >= 0.9.2.1 && < 1,
-                 text >= 0.11 && < 1
+                 text >= 0.11 && < 1.2
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell2010
 


### PR DESCRIPTION
Package text-1.0.0.0 is already out, so allow that.  Also assume that
the next text version won't break things either, so allow text-1.1
too.

Tested on a local cabal sandbox by running unit tests.

Fixes #38
