### PR TITLE
Move release history into changelog from the cabal file

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,0 +1,95 @@
+v2.3.11
+
+	* Add support for URI filenames, and default to having them
+	  on. Among other things, this enables using in-memory databases.
+
+v2.3.10
+
+	* Add support for compiling the bundled SQLite3 with URI filename
+	  support. Specifying flags that would have affected the bundled
+	  SQLite3 no longer causes build failure if the "systemlib" flag
+	  is specified.
+
+v2.3.9
+
+	* Update bounds on the requirement on the "text" library.
+
+v2.3.8
+
+	* Upgrade bundled SQLite3 to 3.8.1.
+
+v2.3.7
+
+	* Fix a test failure related to 64-bit math on column indices.
+
+v2.3.6
+
+	* Re-apply the stat64 hack after upgrade to the bundled
+SQLite3.  Oops!
+
+v2.3.5
+
+	* Add support to compile bundled SQLite3 with full-text
+	  search.  Upgrade bundled SQLite3 to 3.7.17.
+
+v2.3.4
+
+	* Work around a linker error on some systems; add column-name
+	  reporting.
+
+v2.3.3.1
+
+	* Upgrade bundled SQLite3 to 3.7.15.2.
+
+v2.3.3
+
+	* Add trace support, as a feature for debugging.
+
+v2.3.2
+
+	* Add execPrint, execWithCallback, and interruptibly functions.
+	  Add bindings for sqlite3_last_insert_rowid and sqlite3_changes.
+	  Change the Show instance of the Utf8 newtype to better match the
+	  IsString instance.
+
+v2.3.1
+
+	* Upgrade the bundled SQLite3 to 3.7.15.  Add bindings for
+	  sqlite3_interrupt.  Export Int rather than CInt.
+
+v2.3
+
+	* Mark some FFI calls "unsafe", for a substantial performance
+	  benefit.
+
+v2.2.1
+
+	* Bump down text library version to match with the latest Haskell
+	  Platform.
+
+v2.2
+
+	* Actually does what version 2.1 claimed to, since the author made
+	  a mistake with git.
+
+v2.1
+
+	* Improves handling of invalid UTF-8 and changes error handling to
+	  be more complete.  It also adds a build flag to build against the
+	  system sqlite instead of the bundled one, optionally
+	  (disabled by default).
+
+v2.0
+
+	* Uses Text for strings instead of String.
+
+v1.1.0.1
+
+	* Switches to the Faction packaging system and makes
+	  no other changes.
+
+v1.1
+
+	* Adds the SQLite amalgamation file (version 3.7.5) to the
+	  project, so that there are no external dependencies.
+

--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -18,62 +18,11 @@ description:
   bindings-sqlite3, it is slightly higher-level, in that it supports
   marshalling of data values to and from the database.  In particular, it
   supports strings encoded as UTF8, and BLOBs represented as ByteStrings.
-  .
-  Release history:
-  .
-  [Version 2.3.11] Add support for URI filenames, and default to having them on. Among other things, this enables using in-memory databases.
-  .
-  [Version 2.3.10] Add support for compiling the bundled SQLite3 with URI filename support. Specifying flags that would have affected the bundled SQLite3 no longer causes build failure if the "systemlib" flag is specified.
-  .
-  [Version 2.3.9] Update bounds on the requirement on the "text" library.
-  .
-  [Version 2.3.8] Upgrade bundled SQLite3 to 3.8.1.
-  .
-  [Version 2.3.7] Fix a test failure related to 64-bit math on column indices.
-  .
-  [Version 2.3.6] Re-apply the stat64 hack after upgrade to the bundled
-  SQLite3.  Oops!
-  .
-  [Version 2.3.5] Add support to compile bundled SQLite3 with full-text search.  Upgrade bundled SQLite3 to 3.7.17.
-  .
-  [Version 2.3.4] Work around a linker error on some systems; add
-  column-name reporting.
-  .
-  [Version 2.3.3.1] Upgrade bundled SQLite3 to 3.7.15.2.
-  .
-  [Version 2.3.3] Add trace support, as a feature for debugging.
-  .
-  [Version 2.3.2] Add execPrint, execWithCallback, and interruptibly functions.
-  Add bindings for sqlite3_last_insert_rowid and sqlite3_changes.  Change the
-  Show instance of the Utf8 newtype to better match the IsString instance.
-  .
-  [Version 2.3.1] Upgrade the bundled SQLite3 to 3.7.15.  Add bindings for
-  sqlite3_interrupt.  Export Int rather than CInt.
-  .
-  [Version 2.3] Mark some FFI calls "unsafe", for a substantial performance
-  benefit.
-  .
-  [Version 2.2.1] Bump down text library version to match with the
-  latest Haskell Platform.
-  .
-  [Version 2.2] actually does what version 2.1 claimed to, since the author
-  made a mistake with git.
-  .
-  [Version 2.1] improves handling of invalid UTF-8 and changes error handling
-  to be more complete.  It also adds a build flag to build against the system
-  sqlite instead of the bundled one, optionally (disabled by default).
-  .
-  [Version 2.0] uses Text for strings instead of String.
-  .
-  [Version 1.1.0.1] switches to the Faction packaging system and makes no other
-  changes.
-  .
-  [Version 1.1] adds the SQLite amalgamation file (version 3.7.5) to the
-  project, so that there are no external dependencies.
 
 extra-source-files:
   cbits/sqlite3.c
   cbits/sqlite3.h
+  changelog
 
 Source-Repository head
   type: git


### PR DESCRIPTION
The cabal file based release history eats up almost a full browser
window of space on the direct-sqlite Hackage page.  Rather than
keeping this long history on the main package page, move it into a
separate changelog file.  Hackage will automatically link to this
changelog file, so that those who're interested in it, can view it
easily without checking out the package contents.
