### PR TITLE
Fix doc syntax error for bindNamed

### DIFF
--- a/Database/SQLite3.hs
+++ b/Database/SQLite3.hs
@@ -488,8 +488,11 @@ bind statement sqlData = do
 -- if an unknown name is used.
 --
 -- Example:
--- >> stmt <- prepare conn "SELECT :foo + :bar"
--- >> bindNamed stmt [(":foo", SQLInteger 1), (":bar", SQLInteger 2)]
+--
+-- @
+-- stmt <- prepare conn \"SELECT :foo + :bar\"
+-- bindNamed stmt [(\":foo\", SQLInteger 1), (\":bar\", SQLInteger 2)]
+-- @
 bindNamed :: Statement -> [(T.Text, SQLData)] -> IO ()
 bindNamed statement params = do
     ParamIndex nParams <- bindParameterCount statement


### PR DESCRIPTION
Haddock is ... pretty much a PITA when it comes down to typing down code examples.  So of course I had a syntax error in my previous PR that makes the docs for bindNamed disappear on Hackage.  Obviously no need to release soon, just batching it up here.
