### PR TITLE
Bump version bounds for text 1.2.0.0 (released September 9, 2014)

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -74,8 +74,8 @@ Library
 
   include-dirs: .
   build-depends: base >= 4.1 && < 5,
-                 bytestring >= 0.9.2.1 && < 1,
-                 text >= 0.11 && < 1.2
+                 bytestring >= 0.9.2.1,
+                 text >= 0.11
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell2010
 


### PR DESCRIPTION
Right now, bytestring is on 0.10.4.0 (not affected by < 1), and text is on 1.2.0.0 (affected by < 1.2).  This lets direct-sqlite be built with the latest version of the text package (released on September 9, 2014).  I tested cabal install and cabal test do work with these packages under GHC 7.8.3 and cabal-install 1.20.0.3.

I'm not a fan of putting upper bounds on dependencies everywhere, nor is most of the Haskell community (I think...I could be wrong).  They force us to update bounds every time a new version of a dependency comes out.  On the other hand, this forces us to test to make sure our code actually works with the new version.

This pull request removes the upper bounds entirely.  If you instead prefer upper bounds on dependencies, please:
- Bump the upper bound of text so we can build with 1.2.
- Fix the bound on bytestring to be < 0.10 instead of < 1.  That, or fix text to be < 2.  As is, the comparisons are inconsistent; the bytestring bound waits for A.x.x.x to change, while the text bound waits for A.B.x.x to change.
