### PR TITLE
Allow text-1.2 (#50)

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+v2.3.14
+	* Allow text-1.2
+
 v2.3.13
     * Add support for named parameters to queries.  Split this changelog into
       a separate file (preserving its history).

--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -75,7 +75,7 @@ Library
   include-dirs: .
   build-depends: base >= 4.1 && < 5,
                  bytestring >= 0.9.2.1 && < 1,
-                 text >= 0.11 && < 1.2
+                 text >= 0.11 && < 1.3
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell2010
 


### PR DESCRIPTION
Hi @IreneKnapp, this allows text-1.2.  It'd be good to put this up on Hackage soon so that anyone trying to use text-1.2 won't run into problems.

I'm not sure if I'm up to date with all the other features since the previous release in April.  I think some PRs have gone in, but I guess those are not released to Hackage yet.  I only added what I changed into changelog.
