### PR TITLE
Assorted improvements

### DIFF
--- a/Database/SQLite3.hs
+++ b/Database/SQLite3.hs
@@ -38,6 +38,7 @@ module Database.SQLite3 (
     bindDouble,
     bindText,
     bindBlob,
+    bindZeroBlob,
     bindNull,
 
     -- * Reading the result row
@@ -75,6 +76,7 @@ module Database.SQLite3 (
     funcResultDouble,
     funcResultText,
     funcResultBlob,
+    funcResultZeroBlob,
     funcResultNull,
     getFuncContextDatabase,
 
@@ -140,6 +142,7 @@ import Database.SQLite3.Direct
     , funcResultInt64
     , funcResultDouble
     , funcResultBlob
+    , funcResultZeroBlob
     , funcResultNull
     , getFuncContextDatabase
     , lastInsertRowId
@@ -465,6 +468,11 @@ bindBlob :: Statement -> ParamIndex -> ByteString -> IO ()
 bindBlob statement parameterIndex byteString =
     Direct.bindBlob statement parameterIndex byteString
         >>= checkError (DetailStatement statement) "bind blob"
+
+bindZeroBlob :: Statement -> ParamIndex -> Int -> IO ()
+bindZeroBlob statement parameterIndex len =
+    Direct.bindZeroBlob statement parameterIndex len
+        >>= checkError (DetailStatement statement) "bind zeroblob"
 
 bindDouble :: Statement -> ParamIndex -> Double -> IO ()
 bindDouble statement parameterIndex datum =

--- a/Database/SQLite3.hs
+++ b/Database/SQLite3.hs
@@ -76,6 +76,7 @@ module Database.SQLite3 (
     funcResultText,
     funcResultBlob,
     funcResultNull,
+    getFuncContextDatabase,
 
     -- * Create custom collations
     createCollation,
@@ -140,6 +141,7 @@ import Database.SQLite3.Direct
     , funcResultDouble
     , funcResultBlob
     , funcResultNull
+    , getFuncContextDatabase
     , lastInsertRowId
     , changes
     , interrupt

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -38,6 +38,7 @@ module Database.SQLite3.Bindings (
     -- * Binding Values To Prepared Statements
     -- | <http://www.sqlite.org/c3ref/bind_blob.html>
     c_sqlite3_bind_blob,
+    c_sqlite3_bind_zeroblob,
     c_sqlite3_bind_text,
     c_sqlite3_bind_double,
     c_sqlite3_bind_int64,
@@ -273,6 +274,10 @@ foreign import ccall unsafe "sqlite3_bind_blob"
         -> CNumBytes        -- ^ Length, in bytes.  This must not be negative.
         -> Ptr CDestructor
         -> IO CError
+
+foreign import ccall unsafe "sqlite3_bind_zeroblob"
+    c_sqlite3_bind_zeroblob
+        :: Ptr CStatement -> CParamIndex -> CInt -> IO CError
 
 foreign import ccall unsafe "sqlite3_bind_text"
     c_sqlite3_bind_text

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -114,6 +114,15 @@ module Database.SQLite3.Bindings (
     c_sqlite3_blob_bytes,
     c_sqlite3_blob_read,
     c_sqlite3_blob_write,
+
+    -- * Online Backup API
+    -- | <https://www.sqlite.org/backup.html> and
+    -- <https://www.sqlite.org/c3ref/backup_finish.html>
+    c_sqlite3_backup_init,
+    c_sqlite3_backup_finish,
+    c_sqlite3_backup_step,
+    c_sqlite3_backup_remaining,
+    c_sqlite3_backup_pagecount,
 ) where
 
 import Database.SQLite3.Bindings.Types
@@ -500,3 +509,24 @@ foreign import ccall "sqlite3_blob_read"
 -- | <https://www.sqlite.org/c3ref/blob_write.html>
 foreign import ccall "sqlite3_blob_write"
     c_sqlite3_blob_write :: Ptr CBlob -> Ptr a -> CInt -> CInt -> IO CError
+
+
+foreign import ccall "sqlite3_backup_init"
+    c_sqlite3_backup_init
+        :: Ptr CDatabase  -- ^ Destination database handle
+        -> CString        -- ^ Destination database name
+        -> Ptr CDatabase  -- ^ Source database handle
+        -> CString        -- ^ Source database name
+        -> IO (Ptr CBackup)
+
+foreign import ccall "sqlite3_backup_finish"
+    c_sqlite3_backup_finish :: Ptr CBackup -> IO CError
+
+foreign import ccall "sqlite3_backup_step"
+    c_sqlite3_backup_step :: Ptr CBackup -> CInt -> IO CError
+
+foreign import ccall unsafe "sqlite3_backup_remaining"
+    c_sqlite3_backup_remaining :: Ptr CBackup -> IO CInt
+
+foreign import ccall unsafe "sqlite3_backup_pagecount"
+    c_sqlite3_backup_pagecount :: Ptr CBackup -> IO CInt

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -5,6 +5,7 @@ module Database.SQLite3.Bindings (
     -- * Connection management
     c_sqlite3_open,
     c_sqlite3_close,
+    c_sqlite3_errcode,
     c_sqlite3_errmsg,
     c_sqlite3_interrupt,
     c_sqlite3_trace,
@@ -130,6 +131,10 @@ foreign import ccall "sqlite3_open"
 -- | <http://www.sqlite.org/c3ref/close.html>
 foreign import ccall "sqlite3_close"
     c_sqlite3_close :: Ptr CDatabase -> IO CError
+
+-- | <http://www.sqlite.org/c3ref/errcode.html>
+foreign import ccall "sqlite3_errcode"
+    c_sqlite3_errcode :: Ptr CDatabase -> IO CError
 
 -- | <http://www.sqlite.org/c3ref/errcode.html>
 foreign import ccall "sqlite3_errmsg"

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -11,6 +11,7 @@ module Database.SQLite3.Bindings (
     CTraceCallback,
     mkCTraceCallback,
     c_sqlite3_get_autocommit,
+    c_sqlite3_enable_shared_cache,
 
     -- * Simple query execution
     -- | <http://sqlite.org/c3ref/exec.html>
@@ -141,6 +142,10 @@ foreign import ccall "sqlite3_trace"
 -- | <http://www.sqlite.org/c3ref/get_autocommit.html>
 foreign import ccall unsafe "sqlite3_get_autocommit"
     c_sqlite3_get_autocommit :: Ptr CDatabase -> IO CInt
+
+-- | <https://www.sqlite.org/c3ref/enable_shared_cache.html>
+foreign import ccall unsafe "sqlite3_enable_shared_cache"
+    c_sqlite3_enable_shared_cache :: CInt -> IO CError
 
 
 foreign import ccall "sqlite3_exec"

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -105,6 +105,14 @@ module Database.SQLite3.Bindings (
     c_sqlite3_wal_hook,
     CWalHook,
     mkCWalHook,
+
+    -- * Incremental blob I/O
+    c_sqlite3_blob_open,
+    c_sqlite3_blob_close,
+    c_sqlite3_blob_reopen,
+    c_sqlite3_blob_bytes,
+    c_sqlite3_blob_read,
+    c_sqlite3_blob_write,
 ) where
 
 import Database.SQLite3.Bindings.Types
@@ -454,3 +462,36 @@ type CWalHook = Ptr () -> Ptr CDatabase -> CString -> CInt -> IO CError
 
 foreign import ccall "wrapper"
     mkCWalHook :: CWalHook -> IO (FunPtr CWalHook)
+
+
+-- | <https://www.sqlite.org/c3ref/blob_open.html>
+foreign import ccall "sqlite3_blob_open"
+    c_sqlite3_blob_open
+        :: Ptr CDatabase
+        -> CString         -- ^ Database name
+        -> CString         -- ^ Table name
+        -> CString         -- ^ Column name
+        -> Int64           -- ^ Row ROWID
+        -> CInt            -- ^ Flags
+        -> Ptr (Ptr CBlob) -- ^ OUT: Blob handle, will be NULL on error
+        -> IO CError
+
+-- | <https://www.sqlite.org/c3ref/blob_close.html>
+foreign import ccall "sqlite3_blob_close"
+    c_sqlite3_blob_close :: Ptr CBlob -> IO CError
+
+-- | <https://www.sqlite.org/c3ref/blob_reopen.html>
+foreign import ccall "sqlite3_blob_reopen"
+    c_sqlite3_blob_reopen :: Ptr CBlob -> Int64 -> IO CError
+
+-- | <https://www.sqlite.org/c3ref/blob_bytes.html>
+foreign import ccall unsafe "sqlite3_blob_bytes"
+    c_sqlite3_blob_bytes :: Ptr CBlob -> IO CInt
+
+-- | <https://www.sqlite.org/c3ref/blob_read.html>
+foreign import ccall "sqlite3_blob_read"
+    c_sqlite3_blob_read :: Ptr CBlob -> Ptr a -> CInt -> CInt -> IO CError
+
+-- | <https://www.sqlite.org/c3ref/blob_write.html>
+foreign import ccall "sqlite3_blob_write"
+    c_sqlite3_blob_write :: Ptr CBlob -> Ptr a -> CInt -> CInt -> IO CError

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -97,7 +97,12 @@ module Database.SQLite3.Bindings (
     c_sqlite3_free,
 
     -- * Extensions
-    c_sqlite3_enable_load_extension
+    c_sqlite3_enable_load_extension,
+
+    -- * Write-Ahead Log Commit Hook
+    c_sqlite3_wal_hook,
+    CWalHook,
+    mkCWalHook,
 ) where
 
 import Database.SQLite3.Bindings.Types
@@ -429,3 +434,13 @@ foreign import ccall "sqlite3_free"
 -- | <http://sqlite.org/c3ref/enable_load_extension.html>
 foreign import ccall "sqlite3_enable_load_extension"
     c_sqlite3_enable_load_extension :: Ptr CDatabase -> Bool -> IO CError
+
+
+-- | <https://www.sqlite.org/c3ref/wal_hook.html>
+foreign import ccall unsafe "sqlite3_wal_hook"
+    c_sqlite3_wal_hook :: Ptr CDatabase -> FunPtr CWalHook -> Ptr a -> IO (Ptr ())
+
+type CWalHook = Ptr () -> Ptr CDatabase -> CString -> CInt -> IO CError
+
+foreign import ccall "wrapper"
+    mkCWalHook :: CWalHook -> IO (FunPtr CWalHook)

--- a/Database/SQLite3/Bindings/Types.hsc
+++ b/Database/SQLite3/Bindings/Types.hsc
@@ -10,6 +10,7 @@ module Database.SQLite3.Bindings.Types (
     CValue,
     CContext,
     CBlob,
+    CBackup,
 
     -- * Enumerations
 
@@ -124,6 +125,11 @@ data CContext
 --
 -- @CBlob@ = @sqlite3_blob@
 data CBlob
+
+-- | <https://www.sqlite.org/c3ref/backup.html>
+--
+-- @CBackup@ = @sqlite3_backup@
+data CBackup
 
 -- | Index of a parameter in a parameterized query.
 -- Parameter indices start from 1.

--- a/Database/SQLite3/Bindings/Types.hsc
+++ b/Database/SQLite3/Bindings/Types.hsc
@@ -9,6 +9,7 @@ module Database.SQLite3.Bindings.Types (
     CStatement,
     CValue,
     CContext,
+    CBlob,
 
     -- * Enumerations
 
@@ -118,6 +119,11 @@ data CValue
 --
 -- @CContext@ = @sqlite3_context@
 data CContext
+
+-- | <https://www.sqlite.org/c3ref/blob.html>
+--
+-- @CBlob@ = @sqlite3_blob@
+data CBlob
 
 -- | Index of a parameter in a parameterized query.
 -- Parameter indices start from 1.

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -79,6 +79,7 @@ module Database.SQLite3.Direct (
     funcResultText,
     funcResultBlob,
     funcResultNull,
+    getFuncContextDatabase,
 
     -- * Create custom collations
     createCollation,
@@ -715,6 +716,14 @@ funcResultBlob (FuncContext ctx) value =
 funcResultNull :: FuncContext -> IO ()
 funcResultNull (FuncContext ctx) =
     c_sqlite3_result_null ctx
+
+-- | <https://www.sqlite.org/c3ref/context_db_handle.html>
+getFuncContextDatabase :: FuncContext -> IO Database
+getFuncContextDatabase (FuncContext ctx) = do
+    db <- c_sqlite3_context_db_handle ctx
+    if db == nullPtr
+        then fail $ "sqlite3_context_db_handle(" ++ show ctx ++ ") returned NULL"
+        else return (Database db)
 
 
 -- Deallocate the function pointer to the comparison function used to

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -15,6 +15,7 @@ module Database.SQLite3.Direct (
     errmsg,
     setTrace,
     getAutoCommit,
+    setSharedCacheEnabled,
 
     -- * Simple query execution
     -- | <http://sqlite.org/c3ref/exec.html>
@@ -368,6 +369,16 @@ setTrace (Database db) logger =
 getAutoCommit :: Database -> IO Bool
 getAutoCommit (Database db) =
     (/= 0) <$> c_sqlite3_get_autocommit db
+
+
+-- | <https://www.sqlite.org/c3ref/enable_shared_cache.html>
+--
+-- Enable or disable shared cache for all future connections.
+setSharedCacheEnabled :: Bool -> IO (Either Error ())
+setSharedCacheEnabled val =
+    toResult () <$> c_sqlite3_enable_shared_cache
+        (if val then 1 else 0)
+
 
 -- | <http://www.sqlite.org/c3ref/prepare.html>
 --

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -45,6 +45,7 @@ module Database.SQLite3.Direct (
     bindDouble,
     bindText,
     bindBlob,
+    bindZeroBlob,
     bindNull,
 
     -- * Reading the result row
@@ -79,6 +80,7 @@ module Database.SQLite3.Direct (
     funcResultDouble,
     funcResultText,
     funcResultBlob,
+    funcResultZeroBlob,
     funcResultNull,
     getFuncContextDatabase,
 
@@ -495,6 +497,11 @@ bindBlob (Statement stmt) idx value =
         toResult () <$>
             c_sqlite3_bind_blob stmt (toFFI idx) ptr len c_SQLITE_TRANSIENT
 
+bindZeroBlob :: Statement -> ParamIndex -> Int -> IO (Either Error ())
+bindZeroBlob (Statement stmt) idx len =
+    toResult () <$>
+        c_sqlite3_bind_zeroblob stmt (toFFI idx) (fromIntegral len)
+
 bindNull :: Statement -> ParamIndex -> IO (Either Error ())
 bindNull (Statement stmt) idx =
     toResult () <$> c_sqlite3_bind_null stmt (toFFI idx)
@@ -723,6 +730,10 @@ funcResultBlob :: FuncContext -> ByteString -> IO ()
 funcResultBlob (FuncContext ctx) value =
     unsafeUseAsCStringLenNoNull value $ \ptr len ->
         c_sqlite3_result_blob ctx ptr len c_SQLITE_TRANSIENT
+
+funcResultZeroBlob :: FuncContext -> Int -> IO ()
+funcResultZeroBlob (FuncContext ctx) len =
+    c_sqlite3_result_zeroblob ctx (fromIntegral len)
 
 funcResultNull :: FuncContext -> IO ()
 funcResultNull (FuncContext ctx) =

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -12,6 +12,7 @@ module Database.SQLite3.Direct (
     -- * Connection management
     open,
     close,
+    errcode,
     errmsg,
     setTrace,
     getAutoCommit,
@@ -262,6 +263,11 @@ close (Database db) =
 interrupt :: Database -> IO ()
 interrupt (Database db) =
     c_sqlite3_interrupt db
+
+-- | <http://www.sqlite.org/c3ref/errcode.html>
+errcode :: Database -> IO Error
+errcode (Database db) =
+    decodeError <$> c_sqlite3_errcode db
 
 -- | <http://www.sqlite.org/c3ref/errcode.html>
 errmsg :: Database -> IO Utf8

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -248,6 +248,7 @@ testBind :: TestEnv -> Test
 testBind TestEnv{..} = TestCase $ do
   bracket (prepare conn "SELECT ?") finalize testBind1
   bracket (prepare conn "SELECT ?+?") finalize testBind2
+  bracket (prepare conn "SELECT ?,?") finalize testBind3
   where
     testBind1 stmt = do
       let params =  [SQLInteger 3]
@@ -264,6 +265,16 @@ testBind TestEnv{..} = TestCase $ do
       res <- columns stmt
       Done <- step stmt
       assertEqual "two params param" [SQLInteger 2] res
+
+    testBind3 stmt = do
+      let len = 7
+          bs = B.replicate len 0
+      bindBlob stmt 1 bs
+      bindZeroBlob stmt 2 len
+      Row <- step stmt
+      res <- columns stmt
+      Done <- step stmt
+      assertEqual "blob vs. zeroblob" [SQLBlob bs, SQLBlob bs] res
 
 -- Test bindParameterCount
 testBindParamCounts :: TestEnv -> Test


### PR DESCRIPTION
This pull request contains a bunch of assorted additions to the library. I tried to break this into multiple PRs but this resulted in a merge conflict hell. I think it is easier to merge as a single PR and you can still review the individual commits. If you prefer multiple PRs, I can do it.

Here's an overview of the commits:
* *add function for retrieving the db handle from a custom function context*
This is useful when you want to write a custom function that itself performs some sql queries.

* *add low-level bindings to sqlite3_wal_hook*
This is useful when you want to manually control when checkpointing occurs in wal journal mode. Unfortunately, it is not possible to provide high-level bindings to this function in haskell without leaking a `FunPtr`. Thus I only provide the low-level bindings and let the user manage the allocation/deallocation of the `FunPtr`.

* *add support for activating/deactivating the shared cache mode*
This is useful when you have multiple connections to the same database in the same process.

* *add support for zeroblobs*
This is needed for the incremental blob I/O.

* *add support for incremental blob I/O*

* *add bindings for sqlite3_errcode*
This is needed for the online backup api.

* *add support for the online backup api*
