### PR TITLE
Enable use of usleep()

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -59,24 +59,19 @@ Library
       extra-libraries: pthread
     }
     c-sources: cbits/sqlite3.c
-    if flag(fulltextsearch) && flag(urifilenames) {
+
+    if flag(fulltextsearch) {
       cc-options: -DSQLITE_ENABLE_FTS3
                   -DSQLITE_ENABLE_FTS3_PARENTHESIS
                   -DSQLITE_ENABLE_FTS4
-                  -DSQLITE_USE_URI
-    } else {
-      if flag(fulltextsearch) {
-        cc-options: -DSQLITE_ENABLE_FTS3
-                    -DSQLITE_ENABLE_FTS3_PARENTHESIS
-                    -DSQLITE_ENABLE_FTS4
-      }
-      if flag(urifilenames) {
-        cc-options: -DSQLITE_USE_URI
-      }
+    }
 
-      if flag(haveusleep) {
-         cc-options: -DHAVE_USLEEP
-      }
+    if flag(urifilenames) {
+      cc-options: -DSQLITE_USE_URI
+    }
+
+    if flag(haveusleep) {
+       cc-options: -DHAVE_USLEEP
     }
   }
 

--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -40,6 +40,10 @@ flag urifilenames
   description: Enable URI filenames when using the bundled sqlite library
   default: True
 
+flag haveusleep
+  description: Enable use of os function usleep.
+  default: True
+
 Library
   exposed-modules:
     Database.SQLite3
@@ -68,6 +72,10 @@ Library
       }
       if flag(urifilenames) {
         cc-options: -DSQLITE_USE_URI
+      }
+
+      if flag(haveusleep) {
+         cc-options: -DHAVE_USLEEP
       }
     }
   }


### PR DESCRIPTION
Without usleep() sqlite will always sleep for a full second when it need to sleep. This makes the default busy handler very slow. Most operating systems have usleep() today (I guess) but I've added it as a flag so it can be turned off if there still are systems without.