### PR TITLE
Remove 'extra-libraries: pthread' for all OSes

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -60,7 +60,7 @@ Library
     cpp-options: -Ddirect_sqlite_systemlib
     extra-libraries: sqlite3
   } else {
-    if !os(windows) {
+    if !os(windows) && !os(linux-android) {
       extra-libraries: pthread
     }
     c-sources: cbits/sqlite3.c


### PR DESCRIPTION
It's not needed with glibc and prevents building with some newer libc's such as
bionic for Android.