### PR TITLE
Add Semigroup instance to support GHC 8.4.1

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -92,6 +92,7 @@ Library
   include-dirs: .
   build-depends: base >= 4.1 && < 5,
                  bytestring >= 0.9.2.1,
+                 semigroups >= 0.18 && < 0.19,
                  text >= 0.11
   ghc-options: -Wall -fwarn-tabs
   default-language: Haskell2010


### PR DESCRIPTION
Depend on the semigroups package to maintain compatibility with older GHC versions