### PR TITLE
Remove duplicate build-type field and satisfy cabal check

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -11,7 +11,6 @@ bug-reports: https://github.com/IreneKnapp/direct-sqlite/issues/new
 category: Database
 synopsis: Low-level binding to SQLite3.  Includes UTF8 and BLOB support.
 Cabal-version: >= 1.10
-Build-type: Simple
 description:
   This package is not very different from the other SQLite3 bindings out
   there, but it fixes a few deficiencies I was finding.  As compared to
@@ -60,7 +59,7 @@ Library
     cpp-options: -Ddirect_sqlite_systemlib
     extra-libraries: sqlite3
   } else {
-    if !os(windows) && !os(linux-android) {
+    if !os(windows) && !os(android) {
       extra-libraries: pthread
     }
     c-sources: cbits/sqlite3.c


### PR DESCRIPTION
Changing `linux-android` to `android` makes cabal-install 2.0's `cabal check` happy, which means hackage will be happy.
The `build-type` field is also duplicated so I thought I might as well fix that too.