### PR TITLE
Depend on semigroups only on GHC < 8.0

### DIFF
--- a/direct-sqlite.cabal
+++ b/direct-sqlite.cabal
@@ -55,11 +55,13 @@ library
                     Database.SQLite3.Direct
   build-depends:    base       >= 4.1 && < 5
                   , bytestring >= 0.9.2.1
-                  , semigroups >= 0.18 && < 0.20
                   , text       >= 0.11
   default-language: Haskell2010
   include-dirs:     .
   ghc-options:      -Wall -fwarn-tabs
+
+  if impl(ghc < 8.0)
+    build-depends: semigroups >= 0.18 && < 0.20
 
   if flag(systemlib)
     extra-libraries: sqlite3


### PR DESCRIPTION
They are not needed on newer GHC.

as in https://github.com/nurpax/sqlite-simple/commit/ac2165d4028fc09b7afbfbccf56a9b6cacb653e9
closes https://github.com/IreneKnapp/direct-sqlite/issues/94 