### PR TITLE
Add support for enabling extended result codes as default on a connection

### DIFF
--- a/Database/SQLite3.hs
+++ b/Database/SQLite3.hs
@@ -232,6 +232,7 @@ data SQLOpenFlag
     | SQLOpenPrivateCache  -- Ok for sqlite3_open_v2()
     | SQLOpenWAL           -- VFS only
     | SQLOpenNoFollow      -- Ok for sqlite3_open_v2()
+    | SQLOpenExResCode     -- Extended result codes
     deriving (Eq, Show)
 
 -- | These VFS names are used when using the `open2` function.
@@ -371,6 +372,7 @@ open2 path flags zvfs =
         toNum SQLOpenPrivateCache   = 0x00040000
         toNum SQLOpenWAL            = 0x00080000
         toNum SQLOpenNoFollow       = 0x01000000
+        toNum SQLOpenExResCode      = 0x02000000
 
 -- | <https://www.sqlite.org/c3ref/close.html>
 close :: Database -> IO ()

--- a/Database/SQLite3/Bindings.hs
+++ b/Database/SQLite3/Bindings.hs
@@ -9,6 +9,7 @@ module Database.SQLite3.Bindings (
     c_sqlite3_errcode,
     c_sqlite3_extended_errcode,
     c_sqlite3_errmsg,
+    c_sqlite3_extended_result_codes,
     c_sqlite3_interrupt,
     c_sqlite3_trace,
     CTraceCallback,
@@ -165,6 +166,10 @@ foreign import ccall unsafe "sqlite3_extended_errcode"
 -- | <https://www.sqlite.org/c3ref/errcode.html>
 foreign import ccall unsafe "sqlite3_errmsg"
     c_sqlite3_errmsg :: Ptr CDatabase -> IO CString
+
+-- | <https://www.sqlite.org/c3ref/extended_result_codes.html>
+foreign import ccall unsafe "sqlite3_extended_result_codes"
+    c_sqlite3_extended_result_codes :: Ptr CDatabase -> Bool -> IO CError
 
 -- | <https://www.sqlite.org/c3ref/interrupt.html>
 foreign import ccall "sqlite3_interrupt"

--- a/Database/SQLite3/Direct.hs
+++ b/Database/SQLite3/Direct.hs
@@ -16,6 +16,7 @@ module Database.SQLite3.Direct (
     errcode,
     extendedErrcode,
     errmsg,
+    setExtendedResultCodes,
     setTrace,
     getAutoCommit,
     setSharedCacheEnabled,
@@ -313,6 +314,11 @@ errcode (Database db) =
 extendedErrcode :: Database -> IO Error
 extendedErrcode (Database db) =
     decodeError <$> c_sqlite3_extended_errcode db
+
+-- | <https://www.sqlite.org/c3ref/extended_result_codes.html>
+setExtendedResultCodes :: Database -> Bool -> IO (Either Error ())
+setExtendedResultCodes (Database db) enabled =
+    toResult () <$> c_sqlite3_extended_result_codes db enabled
 
 -- | <https://www.sqlite.org/c3ref/errcode.html>
 errmsg :: Database -> IO Utf8


### PR DESCRIPTION
- Added support for the `SQLITE_OPEN_EXRESCODE` `sqlite3_open_v2` flag, which enables by-default extended result codes on connections it opens (and also causes `sqlite3_open_v2` itself to return extended result codes)
- Added the `sqlite3_extended_result_codes` function to switch between primary and extended result codes on an existing connection

There's one thing that may need to be changed before this can be merged: with extended result codes enabled for a given connection, there are now two possible "success" results (not counting `SQLITE_ROW` and `SQLITE_DONE`) -- `SQLITE_OK` and `SQLITE_OK_LOAD_PERMANENTLY` -- while `Database.SQLite3.Direct.toResult`(`M`) considers anything not exactly `SQLITE_OK` to be an error. This shouldn't be a problem unless this library adds support for `sqlite3_load_extension`, though (https://www.sqlite.org/rescode.html#ok_load_permanently), and should be a simple fix (`toResult` can mask off the 8 least significant bits before comparing to 0). 